### PR TITLE
Fix - Should not be a space after -i in SEDOPT

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -34,7 +34,7 @@ RM="/bin/rm"
 RMOPTS="-rf"
 
 SED="/usr/bin/sed"
-SEDOPTS="-i ''"
+SEDOPTS="-i''"
 SEDEXPR="s@$DEFDIR@$PREFIX@g"
 
 builtin cd ..

--- a/tools/test.sh
+++ b/tools/test.sh
@@ -15,7 +15,7 @@ MDLDIR="/usr/local/opt/git-follow/src"
 SRCDIR="src"
 
 SED="/usr/bin/sed"
-SEDOPTS="-i ''"
+SEDOPTS="-i''"
 SEDEXPR="s@$MDLDIR@$SRCDIR@g"
 
 # Update 'use lib' directive to 'src' for testing purposes.


### PR DESCRIPTION
Ran into problems when running make and ./test, the sed option -i should not have a space between -i and ''

* Fixes the sed expression in the test and install script
* Alternatively one could also use --in-place=[SUFFIX] instead but I opted to just remove the space