### PR TITLE
Fix missing import and module 1;

### DIFF
--- a/src/GitFollow/Cli/OptionsNormalizer.pm
+++ b/src/GitFollow/Cli/OptionsNormalizer.pm
@@ -10,7 +10,6 @@ use strict;
 use warnings;
 use Exporter qw(import);
 use GitFollow::Log qw(parse_opts);
-use GitFollow::Stdlib::NumberUtils qw(is_numeric);
 
 our @EXPORT_OK = qw(
 	format

--- a/src/GitFollow/Log.pm
+++ b/src/GitFollow/Log.pm
@@ -10,6 +10,7 @@ use strict;
 use warnings;
 use Exporter qw(import);
 use GitFollow::Environment qw($GIT_PATH);
+use GitFollow::Stdlib::NumberUtils qw(is_numeric);
 
 our @EXPORT_OK = qw(
 	parse_opts

--- a/src/GitFollow/Stdlib/NumberUtils.pm
+++ b/src/GitFollow/Stdlib/NumberUtils.pm
@@ -20,3 +20,5 @@ sub is_numeric {
 	return (defined $num)
 	    ? ($num =~ /^\d+$/ ? 1 : 0) : 0;
 }
+
+1;


### PR DESCRIPTION
Kept getting the following error: 
`Undefined subroutine &GitFollow::Log::is_numeric called at /usr/local/opt/git-follow/src/GitFollow/Log.pm line 93.
`
Seems like the import was missing, and for some reason it was being imported in the OptionsNormalizer